### PR TITLE
Add __version__ string

### DIFF
--- a/pyopengltk/__init__.py
+++ b/pyopengltk/__init__.py
@@ -17,6 +17,10 @@
 #  http://www.codeproject.com/Articles/1073475/OpenGL-in-Python-with-TKinter
 #
 # Large parts copied from pyopengl/Tk/__init__.py
+
+__author__  = "Jon Wright"
+__version__ = "0.0.3"
+
 import sys
 
 # Platform specific frames


### PR DESCRIPTION
I am currently in the process of integrating this library as a Tkinter backend for [VisPy](https://github.com/vispy/vispy/).

It would be beneficial to know the version number so it can be used in tests and to check compatibility, hence this pull request to add the `__version__` string.

([My pull request into VisPy for reference](https://github.com/vispy/vispy/pull/1918))