### PR TITLE
add __init__ to linux.py and win32.py

### DIFF
--- a/pyopengltk/linux.py
+++ b/pyopengltk/linux.py
@@ -47,6 +47,9 @@ fbatt = [
 # Inherits the base and fills in the 3 platform dependent functions
 class OpenGLFrame(BaseOpenGLFrame):
 
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+
     def tkCreateContext(self):
         self.__window = XOpenDisplay(self.winfo_screen().encode('utf-8'))
         # Check glx version:

--- a/pyopengltk/win32.py
+++ b/pyopengltk/win32.py
@@ -29,6 +29,9 @@ pfd.iLayerType = PFD_MAIN_PLANE
 # Inherits the base and fills in the 3 platform dependent functions
 class OpenGLFrame(BaseOpenGLFrame):
 
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+
     def tkCreateContext(self):
         self.__window = GetDC(self.winfo_id())
         pixelformat = ChoosePixelFormat(self.__window, pfd)


### PR DESCRIPTION
I just wanted to create __init__ in linux.py and win32.py, so that I don't get warnings like  "Instance attribute xx defined outside __init__ ", when I create a new class from your 'OpenGLFrame' class.

like this example:

```python
class TkinterOpenGL(OpenGLFrame):
    def __init__(self, master, /, *args, width, height):
        super().__init__(master=master, width=width, height=height)

        self.paths = args
        self.oglobj = None
```

I hope there is nothing wrong with this.. I think it is completely compatible.

I plan to use this in my project so It would be nice to not have to modify your code if there are going to be updates